### PR TITLE
dmarc-visualizerの導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/files/
+/output_files/
+/parsedmarc/GeoLite2-Country*
+/elastic_data/

--- a/README.md
+++ b/README.md
@@ -7,5 +7,17 @@ DMARCレポートをgmailから取得して解析を行ってくれるシステ�
 docker compose up --build
 ```
 
+## DMARCレポート取得のための設定方法
+TODO
+
+## 解析結果の確認方法
+Grafanaというデータを可視化するソフトウェアを使用しています。  
+Grafanaコンテナを立ち上げ、ブラウザで3000番ポートでアクセスしてください。  
+```
+# 例
+http://192.168.56.2:3000/
+```
+
+
 ## 参考
 [dmarc-visualizer](https://github.com/debricked/dmarc-visualizer)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # dmarc-analyzer
+
+DMARCレポートをgmailから取得して解析を行ってくれるシステムです。
+
+## セットアップ
+```
+docker compose up --build
+```
+
+## 参考
+[dmarc-visualizer](https://github.com/debricked/dmarc-visualizer)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.5'
+services:
+  parsedmarc:
+    build: ./parsedmarc/
+    volumes:
+      - ./files:/input:ro
+      - ./output_files:/output
+    command: parsedmarc -c /parsedmarc.ini /input/* --debug
+    depends_on:
+      - elasticsearch
+    restart: on-failure
+    container_name: parsedmarc
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.5
+    ports:
+      - 9200:9200
+    environment:
+      - discovery.type=single-node
+    volumes:
+      - ./elastic_data:/usr/share/elasticsearch/data
+    container_name: elasticsearch
+
+  grafana:
+    build: ./grafana/
+    ports:
+      - 3000:3000
+    user: root
+    environment:
+      GF_INSTALL_PLUGINS: grafana-piechart-panel,grafana-worldmap-panel
+      GF_AUTH_ANONYMOUS_ENABLED: 'true'
+      GF_SMTP_ENABLED: true
+      GF_SMTP_HOST: mocksmtp:1025
+      GF_SMTP_USER: 
+      GF_SMTP_PASSWORD: 
+      GF_SMTP_FROM_ADDRESS: grafana@example.com
+      GF_SMTP_FROM_NAME: Grafana"
+    container_name: grafana
+
+  # grafanaの通知テスト用
+  mocksmtp:
+    container_name: mocksmtp
+    image: pocari/mailcatcher:v2
+    ports:
+      - "1080:1080"
+      - "1025:1025"

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,6 @@
+FROM grafana/grafana:11.6.1
+
+ADD --chown=grafana:root https://raw.githubusercontent.com/domainaware/parsedmarc/master/grafana/Grafana-DMARC_Reports.json /var/lib/grafana/dashboards/
+RUN chmod 644 /etc/grafana/provisioning
+
+COPY grafana-provisioning/ /etc/grafana/provisioning/

--- a/grafana/grafana-provisioning/dashboards/all.yml
+++ b/grafana/grafana-provisioning/dashboards/all.yml
@@ -1,0 +1,7 @@
+- name: 'default'
+  org_id: 1
+  path: ''
+  type: 'file'
+  allowUiUpdates: true
+  options:
+    folder: '/var/lib/grafana/dashboards'

--- a/grafana/grafana-provisioning/datasources/all.yml
+++ b/grafana/grafana-provisioning/datasources/all.yml
@@ -1,0 +1,29 @@
+apiVersion: 1
+
+datasources:
+- name: 'dmarc-ag'
+  type: 'elasticsearch'
+  access: 'proxy'
+  orgId: 1
+  url: 'http://elasticsearch:9200'
+  database: '[dmarc_aggregate-]YYYY-MM-DD'
+  isDefault: true
+  jsonData:
+    esVersion: 7.17.5
+    timeField: 'date_range'
+    interval: 'Daily'
+  version: 1
+  editable: false
+- name: 'dmarc-fo'
+  type: 'elasticsearch'
+  access: 'proxy'
+  orgId: 1
+  url: 'http://elasticsearch:9200'
+  database: '[dmarc_forensic-]YYYY-MM-DD'
+  isDefault: false
+  jsonData:
+    esVersion: 7.17.5
+    timeField: 'arrival_date'
+    interval: 'Daily'
+  version: 1
+  editable: false

--- a/parsedmarc/Dockerfile
+++ b/parsedmarc/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-alpine3.16
+
+RUN apk add --update --no-cache libxml2-dev libxslt-dev
+RUN apk add --update --no-cache --virtual .build_deps build-base libffi-dev \
+    && pip install parsedmarc \
+    && apk del .build_deps
+
+COPY parsedmarc.ini /
+#COPY GeoLite2-Country.mmdb /usr/share/GeoIP/GeoLite2-Country.mmdb

--- a/parsedmarc/parsedmarc.ini
+++ b/parsedmarc/parsedmarc.ini
@@ -1,0 +1,8 @@
+[general]
+save_aggregate = True
+save_forensic = True
+output = /output/
+
+[elasticsearch]
+hosts = elasticsearch:9200
+ssl = False


### PR DESCRIPTION
[dmarc-visualizer](https://github.com/debricked/dmarc-visualizer)を移植しました。
この時点でGrafanaからDMARCの解析結果が見えるようになりました。

@lobin-z0x50 
レビューをお願いします。

![image](https://github.com/user-attachments/assets/811fea4c-2743-4270-a257-a9ccabb41743)
