### PR TITLE
DMARCレポートをGmailから取得するRubyスクリプトを作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /output_files/
 /parsedmarc/GeoLite2-Country*
 /elastic_data/
+/ruby/credentials.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/files/
+/output_files/
+/parsedmarc/GeoLite2-Country*
+/elastic_data/

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /parsedmarc/GeoLite2-Country*
 /elastic_data/
 /ruby/credentials.json
+/ruby/token.yaml

--- a/README.md
+++ b/README.md
@@ -3,12 +3,44 @@
 DMARCレポートをgmailから取得して解析を行ってくれるシステムです。
 
 ## セットアップ
+
+### Google Cloud Platformの設定
+
+DMARCレポートを取得するGmailアカウントで以下の設定が必要です。
+
+- GmailAPIの有効化
+- OAuth同意画面の作成
+- OAuth 2.0 クライアントIDの作成
+
+設定方法は以下の資料を参考にしてください。
+https://analytics-x.tech/archives/5613
+
+作成したアプリの公開ステータスは「テスト中」でも問題ありません。
+「テスト中」の場合はテストユーザにGmailアカウントを指定してください。
+
+OAuth 2.0 クライアントIDを作成した際に出力されるjsonファイルは環境変数`CREDENTIALS_PATH`で指定している場所に置いてください。
+指定しない場合は`/app/credentials.json`がデフォルトになります。
+
+### コンテナの立ち上げ
+以下のコマンドでコンテナを立ち上げます。
 ```
 docker compose up --build
 ```
 
-## DMARCレポート取得のための設定方法
-TODO
+
+## アプリの認証（初回のみ）
+初回のみ、Rubyスクリプトを起動すると、以下のようなメッセージが表示されます。
+表示されたURLにブラウザでアクセスし、認証コードを取得して、貼り付けてください。
+
+```
+neo@ubuntu-work:~/repos/dmarc-analyzer$ docker exec -it ruby ruby /app/dmarc_reports_collector.rb
+Open the following URL in the browser and enter the resulting code after authorization:
+<ここにURLが表示される>
+Enter code: <ここに貼り付ける>
+```
+
+認証に成功すると、環境変数`TOKEN_PATH`で指定したパスにファイルが作成されます。
+指定しない場合は`/app/token.yaml`がデフォルトになります。
 
 ## 解析結果の確認方法
 Grafanaというデータを可視化するソフトウェアを使用しています。  
@@ -17,7 +49,6 @@ Grafanaコンテナを立ち上げ、ブラウザで3000番ポートでアクセ
 # 例
 http://192.168.56.2:3000/
 ```
-
 
 ## 参考
 [dmarc-visualizer](https://github.com/debricked/dmarc-visualizer)

--- a/README.md
+++ b/README.md
@@ -7,5 +7,17 @@ DMARCレポートをgmailから取得して解析を行ってくれるシステ�
 docker compose up --build
 ```
 
+## DMARCレポート取得のための設定方法
+TODO
+
+## 解析結果の確認方法
+Grafanaというデータを可視化するソフトウェアを使用しています。  
+Grafanaコンテナを立ち上げ、ブラウザで3000番ポートでアクセスしてください。  
+```
+# 例
+http://192.168.56.2:3000/
+```
+
+
 ## 参考
 [dmarc-visualizer](https://github.com/debricked/dmarc-visualizer)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # dmarc-analyzer
+
+DMARCレポートをgmailから取得して解析を行ってくれるシステムです。
+
+## セットアップ
+```
+docker compose up --build
+```
+
+## 参考
+[dmarc-visualizer](https://github.com/debricked/dmarc-visualizer)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,3 +44,13 @@ services:
     ports:
       - "1080:1080"
       - "1025:1025"
+
+  ruby:
+    container_name: ruby
+    build: ./ruby
+    volumes:
+      - ./ruby:/app
+      - ./files:/files
+    environment:
+      GOOGLE_APPLICATION_CREDENTIALS: /app/credentials.json
+    tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,5 +52,6 @@ services:
       - ./ruby:/app
       - ./files:/files
     environment:
-      GOOGLE_APPLICATION_CREDENTIALS: /app/credentials.json
+      CREDENTIALS_PATH:
+      TOKEN_PATH:
     tty: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.5'
+services:
+  parsedmarc:
+    build: ./parsedmarc/
+    volumes:
+      - ./files:/input:ro
+      - ./output_files:/output
+    command: parsedmarc -c /parsedmarc.ini /input/* --debug
+    depends_on:
+      - elasticsearch
+    restart: on-failure
+    container_name: parsedmarc
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.5
+    ports:
+      - 9200:9200
+    environment:
+      - discovery.type=single-node
+    volumes:
+      - ./elastic_data:/usr/share/elasticsearch/data
+    container_name: elasticsearch
+
+  grafana:
+    build: ./grafana/
+    ports:
+      - 3000:3000
+    user: root
+    environment:
+      GF_INSTALL_PLUGINS: grafana-piechart-panel,grafana-worldmap-panel
+      GF_AUTH_ANONYMOUS_ENABLED: 'true'
+      GF_SMTP_ENABLED: true
+      GF_SMTP_HOST: mocksmtp:1025
+      GF_SMTP_USER: 
+      GF_SMTP_PASSWORD: 
+      GF_SMTP_FROM_ADDRESS: grafana@example.com
+      GF_SMTP_FROM_NAME: Grafana"
+    container_name: grafana
+
+  # grafanaの通知テスト用
+  mocksmtp:
+    container_name: mocksmtp
+    image: pocari/mailcatcher:v2
+    ports:
+      - "1080:1080"
+      - "1025:1025"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
 version: '3.5'
+
+volumes:
+  elastic_data:
+
 services:
   parsedmarc:
     build: ./parsedmarc/
@@ -18,7 +22,7 @@ services:
     environment:
       - discovery.type=single-node
     volumes:
-      - ./elastic_data:/usr/share/elasticsearch/data
+      - elastic_data:/usr/share/elasticsearch/data
     container_name: elasticsearch
 
   grafana:

--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,0 +1,6 @@
+FROM grafana/grafana:11.6.1
+
+ADD --chown=grafana:root https://raw.githubusercontent.com/domainaware/parsedmarc/master/grafana/Grafana-DMARC_Reports.json /var/lib/grafana/dashboards/
+RUN chmod 644 /etc/grafana/provisioning
+
+COPY grafana-provisioning/ /etc/grafana/provisioning/

--- a/grafana/grafana-provisioning/dashboards/all.yml
+++ b/grafana/grafana-provisioning/dashboards/all.yml
@@ -1,0 +1,7 @@
+- name: 'default'
+  org_id: 1
+  path: ''
+  type: 'file'
+  allowUiUpdates: true
+  options:
+    folder: '/var/lib/grafana/dashboards'

--- a/grafana/grafana-provisioning/datasources/all.yml
+++ b/grafana/grafana-provisioning/datasources/all.yml
@@ -1,0 +1,29 @@
+apiVersion: 1
+
+datasources:
+- name: 'dmarc-ag'
+  type: 'elasticsearch'
+  access: 'proxy'
+  orgId: 1
+  url: 'http://elasticsearch:9200'
+  database: '[dmarc_aggregate-]YYYY-MM-DD'
+  isDefault: true
+  jsonData:
+    esVersion: 7.17.5
+    timeField: 'date_range'
+    interval: 'Daily'
+  version: 1
+  editable: false
+- name: 'dmarc-fo'
+  type: 'elasticsearch'
+  access: 'proxy'
+  orgId: 1
+  url: 'http://elasticsearch:9200'
+  database: '[dmarc_forensic-]YYYY-MM-DD'
+  isDefault: false
+  jsonData:
+    esVersion: 7.17.5
+    timeField: 'arrival_date'
+    interval: 'Daily'
+  version: 1
+  editable: false

--- a/parsedmarc/Dockerfile
+++ b/parsedmarc/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.9-alpine3.16
+
+RUN apk add --update --no-cache libxml2-dev libxslt-dev
+RUN apk add --update --no-cache --virtual .build_deps build-base libffi-dev \
+    && pip install parsedmarc \
+    && apk del .build_deps
+
+COPY parsedmarc.ini /
+#COPY GeoLite2-Country.mmdb /usr/share/GeoIP/GeoLite2-Country.mmdb

--- a/parsedmarc/parsedmarc.ini
+++ b/parsedmarc/parsedmarc.ini
@@ -1,0 +1,8 @@
+[general]
+save_aggregate = True
+save_forensic = True
+output = /output/
+
+[elasticsearch]
+hosts = elasticsearch:9200
+ssl = False

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -6,10 +6,15 @@ RUN apt-get update -qq && apt-get install -y \
     libcurl4-openssl-dev \
     libssl-dev \
     libffi-dev \
+    tzdata \
     && rm -rf /var/lib/apt/lists/*
 
 # 必要な gem をインストール
 RUN gem install googleauth google-apis-gmail_v1 fileutils
+
+# タイムゾーン設定
+ENV TZ=Asia/Tokyo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # 作業ディレクトリに移動
 WORKDIR /app

--- a/ruby/Dockerfile
+++ b/ruby/Dockerfile
@@ -1,0 +1,15 @@
+FROM ruby:3.4.4
+
+# 必要なパッケージをインストール
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libffi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# 必要な gem をインストール
+RUN gem install googleauth google-apis-gmail_v1 fileutils
+
+# 作業ディレクトリに移動
+WORKDIR /app

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -1,15 +1,38 @@
 require 'googleauth'
+require 'googleauth/stores/file_token_store'
 require 'google/apis/gmail_v1'
 require 'fileutils'
 require 'date'
 
+OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
+APPLICATION_NAME = 'DMARC Report Fetcher'
+CREDENTIALS_PATH = 'credentials.json'
+TOKEN_PATH = 'token.yaml'
+SCOPE = Google::Apis::GmailV1::AUTH_GMAIL_READONLY
+
+def authorize
+  client_id = Google::Auth::ClientId.from_file(CREDENTIALS_PATH)
+  token_store = Google::Auth::Stores::FileTokenStore.new(file: TOKEN_PATH)
+  authorizer = Google::Auth::UserAuthorizer.new(client_id, SCOPE, token_store)
+  user_id = 'default'
+  credentials = authorizer.get_credentials(user_id)
+  if credentials.nil?
+    url = authorizer.get_authorization_url(base_url: OOB_URI)
+    puts "Open the following URL in the browser and enter the resulting code after authorization:\n" + url
+    print "Enter code: "
+    code = gets
+    credentials = authorizer.get_and_store_credentials_from_code(
+      user_id: user_id, code: code, base_url: OOB_URI
+    )
+  end
+  credentials
+end
+
 # Gmail APIのセットアップ
 Gmail = Google::Apis::GmailV1
 gmail_service = Gmail::GmailService.new
-gmail_service.client_options.application_name = 'DMARC Report Fetcher'
-gmail_service.authorization = Google::Auth.get_application_default(
-  ['https://www.googleapis.com/auth/gmail.readonly']
-)
+gmail_service.client_options.application_name = APPLICATION_NAME
+gmail_service.authorization = authorize
 
 # 引数で日付範囲を受け取る (フォーマット: YYYY-MM-DD)
 start_date = ARGV[0] ? Date.parse(ARGV[0]) : Date.today - 7

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -82,7 +82,7 @@ result.messages.each do |msg|
     file_path = File.join(output_dir, part.filename)
 
     File.open(file_path, 'wb') do |file|
-      file.write(attachment.data.unpack1('m0'))  # Base64デコードして書き込む
+      file.write(attachment.data)
     end
 
     puts "保存しました: #{file_path}"

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -6,8 +6,8 @@ require 'date'
 
 OOB_URI = 'urn:ietf:wg:oauth:2.0:oob'
 APPLICATION_NAME = 'DMARC Report Fetcher'
-CREDENTIALS_PATH = 'credentials.json'
-TOKEN_PATH = 'token.yaml'
+CREDENTIALS_PATH = ENV['CREDENTIALS_PATH'] || '/app/credentials.json'
+TOKEN_PATH = ENV['TOKEN_PATH'] || '/app/token.yaml'
 SCOPE = Google::Apis::GmailV1::AUTH_GMAIL_READONLY
 
 def authorize

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -69,11 +69,14 @@ output_dir = '/files'
 # 各メッセージに対して添付ファイルを保存
 result.messages.each do |msg|
   message = gmail_service.get_user_message(user_id, msg.id)
-  p message
 
-  parts = message.payload.parts || []
+  # partsがnilならpayload自体を配列に
+  # メールの形式によってpartsがnilになることがあるようなので、その場合はpayloadを直接使用する
+  parts = message.payload.parts || [message.payload]
+
   parts.each do |part|
-    next unless part.filename && part.body.attachment_id
+    # 添付ファイルがあるか判定
+    next unless part.filename && part.filename != '' && part.body && part.body.attachment_id
 
     attachment = gmail_service.get_user_message_attachment(user_id, msg.id, part.body.attachment_id)
     file_path = File.join(output_dir, part.filename)

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -79,10 +79,6 @@ loop do
     parts = message.payload.parts || [message.payload]
 
     parts.each do |part|
-      # for debug`
-      #headers = part.headers.map{|h| [h.name, h.value]}.to_h
-      #puts "subject:#{headers['Subject']} received-time:#{Time.parse(headers['X-Received'].split(";")[1]).localtime} "
-
       next unless part.filename && part.filename != '' && part.body && part.body.attachment_id
 
       attachment = gmail_service.get_user_message_attachment(user_id, msg.id, part.body.attachment_id)
@@ -92,7 +88,12 @@ loop do
         file.write(attachment.data)
       end
 
-      puts "保存しました: #{file_path}"
+      headers = part.headers.map{|h| [h.name, h.value]}.to_h
+      received_time = headers['X-Received'] ? Time.parse(headers['X-Received'].split(";")[1]).localtime : nil
+      puts "----------------------------"
+      puts "Subject:#{headers['Subject']}" 
+      puts "Received Time: #{received_time}"
+      puts "File: #{file_path}"
     end
   end
 

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -1,0 +1,61 @@
+require 'googleauth'
+require 'google/apis/gmail_v1'
+require 'fileutils'
+require 'date'
+
+# Gmail APIのセットアップ
+Gmail = Google::Apis::GmailV1
+gmail_service = Gmail::GmailService.new
+gmail_service.client_options.application_name = 'DMARC Report Fetcher'
+gmail_service.authorization = Google::Auth.get_application_default(
+  ['https://www.googleapis.com/auth/gmail.readonly']
+)
+
+# 引数で日付範囲を受け取る (フォーマット: YYYY-MM-DD)
+start_date = ARGV[0] ? Date.parse(ARGV[0]) : Date.today - 7
+end_date   = ARGV[1] ? Date.parse(ARGV[1]) : Date.today
+
+# Gmailの検索クエリを作成
+query = [
+  'has:attachment',
+  'subject:(dmarc)',
+  "after:#{start_date.strftime('%Y/%m/%d')}",
+  "before:#{(end_date + 1).strftime('%Y/%m/%d')}"
+].join(' ')
+
+puts "検索クエリ: #{query}"
+
+# ユーザーID（'me' は認証されたユーザーを指します）
+user_id = 'me'
+
+# メールを検索
+result = gmail_service.list_user_messages(user_id, q: query)
+
+if result.messages.nil? || result.messages.empty?
+  puts "対象のメールは見つかりませんでした。"
+  exit
+end
+
+# 出力先ディレクトリを準備
+output_dir = '/files'
+#FileUtils.mkdir_p(output_dir)
+
+# 各メッセージに対して添付ファイルを保存
+result.messages.each do |msg|
+  message = gmail_service.get_user_message(user_id, msg.id)
+  p message
+
+  parts = message.payload.parts || []
+  parts.each do |part|
+    next unless part.filename && part.body.attachment_id
+
+    attachment = gmail_service.get_user_message_attachment(user_id, msg.id, part.body.attachment_id)
+    file_path = File.join(output_dir, part.filename)
+
+    File.open(file_path, 'wb') do |file|
+      file.write(attachment.data.unpack1('m0'))  # Base64デコードして書き込む
+    end
+
+    puts "保存しました: #{file_path}"
+  end
+end

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -46,7 +46,7 @@ query = [
   'has:attachment',
   'from:(dmarc)',
   "after:#{start_date.to_time.to_i}",
-  "before:#{(end_date + 1).to_time.to_i}" # 日付指定だとPSTタイムゾーンで解釈されるため、UNIXタイムスタンプを使用
+  "before:#{(end_date + 1).to_time.to_i}"
 ].join(' ')
 
 puts "#{start_date} ~ #{end_date} のDMARCレポートを検索します。"
@@ -76,6 +76,7 @@ loop do
 
   result.messages.each do |msg|
     message = gmail_service.get_user_message(user_id, msg.id)
+    # メールの形式によってpartsがnilになることがあるようなので、その場合はpayloadを直接使用する
     parts = message.payload.parts || [message.payload]
 
     parts.each do |part|

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -40,11 +40,13 @@ start_date = ARGV[0] ? Date.parse(ARGV[0]) : (Date.today - 1)
 end_date   = ARGV[1] ? Date.parse(ARGV[1]) : (Date.today - 1)
 
 # Gmailの検索クエリを作成
+# before, afterの指定は日付指定だとPSTタイムゾーンで解釈されてしまうため、UNIXタイムスタンプに変換する
+# https://developers.google.com/workspace/gmail/api/guides/filtering?hl=ja
 query = [
   'has:attachment',
-  'subject:(dmarc)',
-  "after:#{start_date.strftime('%Y/%m/%d')}",
-  "before:#{(end_date + 1).strftime('%Y/%m/%d')}"
+  'from:(dmarc)',
+  "after:#{start_date.to_time.to_i}",
+  "before:#{(end_date + 1).to_time.to_i}" # 日付指定だとPSTタイムゾーンで解釈されるため、UNIXタイムスタンプを使用
 ].join(' ')
 
 puts "検索クエリ: #{query}"

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -35,8 +35,9 @@ gmail_service.client_options.application_name = APPLICATION_NAME
 gmail_service.authorization = authorize
 
 # 引数で日付範囲を受け取る (フォーマット: YYYY-MM-DD)
-start_date = ARGV[0] ? Date.parse(ARGV[0]) : Date.today - 7
-end_date   = ARGV[1] ? Date.parse(ARGV[1]) : Date.today
+# 日付を受け取らない場合は、前日分が対象となる
+start_date = ARGV[0] ? Date.parse(ARGV[0]) : (Date.today - 1)
+end_date   = ARGV[1] ? Date.parse(ARGV[1]) : (Date.today - 1)
 
 # Gmailの検索クエリを作成
 query = [

--- a/ruby/dmarc_reports_collector.rb
+++ b/ruby/dmarc_reports_collector.rb
@@ -49,6 +49,7 @@ query = [
   "before:#{(end_date + 1).to_time.to_i}" # 日付指定だとPSTタイムゾーンで解釈されるため、UNIXタイムスタンプを使用
 ].join(' ')
 
+puts "#{start_date} ~ #{end_date} のDMARCレポートを検索します。"
 puts "検索クエリ: #{query}"
 
 # ユーザーID（'me' は認証されたユーザーを指します）


### PR DESCRIPTION
#1 の続きです。

DMARCレポートをGmailから取得するスクリプトです。
とりあえずChatGPTに書いてもらっただけで動作確認していません。

## 実行イメージ
```
# 日付を指定しない場合は昨日分を取得
docker exec ruby ruby dmarc_reports_collector.rb 

#日付の範囲指定も可能
docker exec ruby ruby dmarc_reports_collector.rb 2025-04-01 2025-04-07
```
